### PR TITLE
Fix broken eodag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,6 @@ RUN source ~/.bashrc
 COPY environment.yaml environment.yaml
 RUN micromamba create -f  environment.yaml
 RUN echo "micromamba activate eo_tools" >> ~/.bashrc
+RUN echo "alias conda='micromamba'" >> ~/.bashrc
 
 RUN micromamba activate eo_tools

--- a/environment-cf.yaml
+++ b/environment-cf.yaml
@@ -1,6 +1,5 @@
 name: eo_tools
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.12
@@ -30,5 +29,8 @@ dependencies:
   - numba
   - dask
   - bottleneck
-  # - pip: # must be kept as is to generate .toml
-    # - eodag
+  - websockets 
+  - watchfiles 
+  - uvloop 
+  - python-dotenv 
+  - httptools

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,6 +1,6 @@
 name: eo_tools
 channels:
-  - defaults
+  # - defaults
   - conda-forge
 dependencies:
   - python=3.12
@@ -30,6 +30,12 @@ dependencies:
   - numba
   - dask
   - bottleneck
+  # these are required to avoid eodag to break
+  - websockets 
+  - watchfiles 
+  - uvloop 
+  - python-dotenv 
+  - httptools
   # - pip:
     # - titiler.application
     # - eodag

--- a/notebooks-cf/discover-and-process-s2.ipynb
+++ b/notebooks-cf/discover-and-process-s2.ipynb
@@ -2,12 +2,25 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
+    "\n",
+    "# use this to override local imports\n",
+    "import sys\n",
+    "sys.path.insert(0, \"/root/micromamba/envs/eo_cf/\")\n",
     "\n",
     "import geopandas as gpd\n",
     "import folium\n",
@@ -71,9 +84,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:eodag.core:Searching product type 'S2_MSI_L1C' on provider: cop_dataspace\n",
+      "INFO:eodag.core:Iterate search over multiple pages: page #1\n",
+      "INFO:eodag.search.qssearch:Sending search request: http://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?cloudCover=[0,10]&startDate=2023-06-01&completionDate=2023-08-31&geometry=POLYGON ((-3.3854 48.3264, -3.3854 47.9229, -2.6415 47.9229, -2.6415 48.3264, -3.3854 48.3264))&productType=S2MSI1C&maxRecords=1000&page=1&exactCount=1\n",
+      "INFO:eodag.core:Found 8 result(s) on provider 'cop_dataspace'\n"
+     ]
+    }
+   ],
    "source": [
     "# load a geometry\n",
     "file_aoi = \"../data/Bretagne_AOI.geojson\"\n",

--- a/notebooks-cf/discover-and-process-s2.ipynb
+++ b/notebooks-cf/discover-and-process-s2.ipynb
@@ -2,25 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
     "\n",
-    "# use this to override local imports\n",
-    "import sys\n",
-    "sys.path.insert(0, \"/root/micromamba/envs/eo_cf/\")\n",
+    "\n",
     "\n",
     "import geopandas as gpd\n",
     "import folium\n",
@@ -84,20 +73,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:eodag.core:Searching product type 'S2_MSI_L1C' on provider: cop_dataspace\n",
-      "INFO:eodag.core:Iterate search over multiple pages: page #1\n",
-      "INFO:eodag.search.qssearch:Sending search request: http://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?cloudCover=[0,10]&startDate=2023-06-01&completionDate=2023-08-31&geometry=POLYGON ((-3.3854 48.3264, -3.3854 47.9229, -2.6415 47.9229, -2.6415 48.3264, -3.3854 48.3264))&productType=S2MSI1C&maxRecords=1000&page=1&exactCount=1\n",
-      "INFO:eodag.core:Found 8 result(s) on provider 'cop_dataspace'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# load a geometry\n",
     "file_aoi = \"../data/Bretagne_AOI.geojson\"\n",

--- a/notebooks-cf/download-dem.ipynb
+++ b/notebooks-cf/download-dem.ipynb
@@ -2,17 +2,31 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n",
+      "/root/micromamba/envs/eo_cf/lib/python3.12/site-packages/eo_tools/dem.py\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
     "\n",
+    "# use this to override local imports\n",
+    "import sys\n",
+    "sys.path.insert(0, \"/root/micromamba/envs/eo_cf/\")\n",
+    "\n",
     "import geopandas as gpd\n",
     "from eo_tools.dem import retrieve_dem\n",
     "import logging\n",
-    "\n",
+    " \n",
     "logging.basicConfig(level=logging.INFO)"
    ]
   },
@@ -25,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -45,6 +59,34 @@
     "dem_file = f\"/data/res/cop-dem-glo-30_{aoi_name}.tif\"\n",
     "retrieve_dem(shp, dem_file)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/root/micromamba/envs/eo_cf/lib/python3.12/site-packages/eo_tools/__init__.py'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import eo_tools\n",
+    "eo_tools.__file__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks-cf/download-dem.ipynb
+++ b/notebooks-cf/download-dem.ipynb
@@ -2,26 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n",
-      "/root/micromamba/envs/eo_cf/lib/python3.12/site-packages/eo_tools/dem.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
-    "\n",
-    "# use this to override local imports\n",
-    "import sys\n",
-    "sys.path.insert(0, \"/root/micromamba/envs/eo_cf/\")\n",
     "\n",
     "import geopandas as gpd\n",
     "from eo_tools.dem import retrieve_dem\n",
@@ -39,17 +25,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:eo_tools.dem:Retrieve DEM\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# load a geometry\n",
     "aoi_name = \"Morocco_AOI\"\n",
@@ -59,34 +37,6 @@
     "dem_file = f\"/data/res/cop-dem-glo-30_{aoi_name}.tif\"\n",
     "retrieve_dem(shp, dem_file)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/root/micromamba/envs/eo_cf/lib/python3.12/site-packages/eo_tools/__init__.py'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import eo_tools\n",
-    "eo_tools.__file__"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks-cf/s1-easy-tops-insar.ipynb
+++ b/notebooks-cf/s1-easy-tops-insar.ipynb
@@ -14,6 +14,7 @@
     "\n",
     "import geopandas as gpd\n",
     "from eodag import EODataAccessGateway\n",
+    "import rioxarray as riox\n",
     "\n",
     "# credentials need to be stored in the following file (see EODAG docs)\n",
     "confpath = \"/data/eodag_config.yml\"\n",
@@ -148,6 +149,43 @@
     "\n",
     "# amplitude of the primary image\n",
     "slc2geo(file_amp, file_lut, file_amp_geo, 2, 8, \"bicubic\", False, True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr_amp = riox.open_rasterio(file_amp_geo, masked=True)[0]\n",
+    "arr_amp.plot.imshow(vmin=0,vmax=1, figsize=(7,7), cmap=\"gray\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr_coh = riox.open_rasterio(file_coh_geo, masked=True)[0]\n",
+    "arr_coh.plot.imshow(vmin=0,vmax=1, figsize=(7,7), cmap=\"gray\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr_phi = riox.open_rasterio(file_phi_geo, masked=True)[0]\n",
+    "arr_phi.plot.imshow(vmin=-3.14,vmax=3.14,figsize=(7,7), cmap=\"twilight\")"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eo_tools"
-version = "2024.6.1"
+version = "0.1.0"
 description = "A toolbox for easily searching, downloading & processing remote sensing imagery from various public sources. "
-dependencies = [ "python==3.12.3", "pytest==7.4.0", "gdal==3.8.5", "rasterio==1.3.10", "pyrosar==0.24.0", "spatialist==0.13.1", "pip==24.0", "pystac==1.10.1", "pystac-client==0.8.1", "geopandas==0.14.2", "pandas==2.1.4", "ipykernel==6.28.0", "ipywidgets==8.1.2", "black==24.3.0", "scikit-image==0.22.0", "ipyleaflet==0.17.4", "folium==0.14.0", "tqdm==4.66.4", "xmltodict==0.13.0", "httpx==0.26.0", "xarray==2023.6.0", "netcdf4==1.6.5", "rioxarray==0.15.5", "numba==0.59.1", "dask==2024.5.0", "bottleneck==1.3.7", "eodag==2.12.1",]
+dependencies = [ "python==3.12.3", "pytest==8.2.2", "gdal==3.8.5", "rasterio==1.3.10", "pyrosar==0.24.0", "spatialist==0.13.1", "pip==24.0", "pystac==1.10.1", "pystac-client==0.8.1", "geopandas==0.14.4", "pandas==2.2.2", "eodag==2.12.1", "ipykernel==6.29.3", "ipywidgets==8.1.3", "black==24.4.2", "scikit-image==0.23.2", "ipyleaflet==0.19.1", "folium==0.16.0", "tqdm==4.66.4", "xmltodict==0.13.0", "httpx==0.27.0", "xarray==2024.5.0", "netcdf4==1.6.5", "rioxarray==0.15.5", "numba==0.59.1", "dask==2024.5.2", "bottleneck==1.3.8", "websockets==12.0", "watchfiles==0.22.0", "uvloop==0.19.0", "python-dotenv==1.0.1", "httptools==0.6.1",]
 [[project.authors]]
 name = "Olivier D'Hondt"
 email = "dhondt.olivier@gmail.com"
 
 [tool.setuptools]
-packages = [ "eo_tools", "eo_tools.S1"]
+packages = [ "eo_tools", "eo_tools.S1",]
 include-package-data = true


### PR DESCRIPTION
Some uvicorn dependencies where causing the EODAG package to break.

- Added these dependencies to both environments
- Now both environment use only conda-forge, which will make the docker version consistent with the conda one
- updated pyproject.toml accordingly
- Added a few basic visualizations to some notebooks in `notebooks-cf` since it does not come with titiler (will add to other notebooks as well)